### PR TITLE
Modified datatype of `_offset` from `chrono_t long` to `chrono_t`

### DIFF
--- a/Chrono.h
+++ b/Chrono.h
@@ -61,7 +61,7 @@ public:
   chrono_t _startTime;
 
   // Time offset.
-  chrono_t long _offset;
+  chrono_t _offset;
 
   // Time function.
   chrono_t (*_getTime)(void);


### PR DESCRIPTION
Even though `gcc` accepts the former and compiles, VSCode Intellisense complains about it. Looking through the commit history, prior to b5828419f95d08a2c4fbe04eb04384936a15f5f7 it was `unsigned long`, so I believe the intent is to keep it that way.