### PR TITLE
Correct function name in examples

### DIFF
--- a/examples/Resolutions/Resolutions.ino
+++ b/examples/Resolutions/Resolutions.ino
@@ -17,7 +17,7 @@ void setup() {
 
 void loop() {
   // Output every second.
-  if (secondsChrono.passed(1)) {
+  if (secondsChrono.hasPassed(1)) {
     Serial.println("PING!");
     Serial.print("Millis chrono: "); Serial.println(millisChrono.elapsed());
     Serial.print("Micros chrono: "); Serial.println(microsChrono.elapsed());

--- a/examples/StopResume/StopResume.ino
+++ b/examples/StopResume/StopResume.ino
@@ -11,7 +11,7 @@ void setup() {
 }
 
 void loop() {
-  if (!passedFirstPost && chrono.passed(5000)) {
+  if (!passedFirstPost && chrono.hasPassed(5000)) {
     Serial.println("Stop 5 sec");
     chrono.stop();
     printChrono();
@@ -24,7 +24,7 @@ void loop() {
     printChrono();
     passedFirstPost = true;
   }
-  else if (chrono.passed(10000)) {
+  else if (chrono.hasPassed(10000)) {
     Serial.println("Stop 10 sec");
     chrono.stop();
     printChrono();


### PR DESCRIPTION
The use of the function name `passed()` in these examples caused them to not compile. The correct name is `hasPassed()`.